### PR TITLE
Add simple .clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+Diagnostics:
+  UnusedIncludes: None


### PR DESCRIPTION
Just a proposal. The alternative would be to let everybody set such stuff locally. Opinions welcome. I am open to close the PR without merging. Then we would at least have discussed it.

Rationale for not flagging unused includes is that in MLIR we get a lot of false positives due to these generated headers `*.h.inc` actually requiring some other headers before them.