### PR TITLE
🔧 Reconfigure `prek` priorities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,6 @@ ci:
   autofix_commit_msg: "🎨 pre-commit fixes"
 
 repos:
-  # Priority 0: Fast validation and independent fixers
-
   ## Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -28,7 +26,7 @@ repos:
       - id: end-of-file-fixer
         priority: 1
       - id: trailing-whitespace
-        priority: 1
+        priority: 2
 
   ## Check JSON schemata
   - repo: https://github.com/python-jsonschema/check-jsonschema
@@ -37,7 +35,7 @@ repos:
       - id: check-github-workflows
         priority: 0
 
-  ## Catch common capitalization mistakes
+  ## Check for common capitalization mistakes
   - repo: local
     hooks:
       - id: disallow-caps
@@ -47,24 +45,22 @@ repos:
         exclude: ^(\.pre-commit-config\.yaml)$
         priority: 0
 
-  ## Check for spelling
+  ## Check for typos
   - repo: https://github.com/adhtruong/mirrors-typos
     rev: v1.45.0
     hooks:
       - id: typos
-        priority: 0
+        priority: 3
 
-  # Priority 1: Second-pass fixers
-
-  ## Clang-format the C++ part of the code base automatically
+  ## Format C++ files with clang-format
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.2
+    rev: v22.1.3
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
-        priority: 1
+        priority: 4
 
-  ## Format the CMakeLists.txt files
+  ## Format CMake files with cmake-format
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:
@@ -72,12 +68,12 @@ repos:
         additional_dependencies: [pyyaml]
         types: [file]
         files: (\.cmake|CMakeLists.txt)(.in)?$
-        priority: 1
+        priority: 4
 
   ## Format configuration files with prettier
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.1
+    rev: v3.8.2
     hooks:
       - id: prettier
         types_or: [css, html, markdown, json, json5, scss, yaml]
-        priority: 1
+        priority: 4


### PR DESCRIPTION
This PR reconfigures the `prek` priorities to ensure that no two hooks write at the same time.