### PR TITLE
Update munich-quantum-toolkit/workflows action to v2.0.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,10 +17,6 @@ RUN uv tool install cmake && \
   uv tool install lit && \
   uv tool install prek
 
-ENV LIT_BIN=/usr/local/bin/lit
-
 # Downloads and installs a prebuilt LLVM/MLIR toolchain for the current OS and architecture. Uses `zstd`.
 RUN curl -LsSf https://github.com/munich-quantum-software/setup-mlir/releases/latest/download/setup-mlir.sh \
   | bash -s -- -v 22.1.0 -p /opt/llvm
-
-ENV MLIR_DIR=/opt/llvm/lib/cmake/mlir

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,10 @@ RUN uv tool install cmake && \
   uv tool install lit && \
   uv tool install prek
 
+ENV LIT_BIN=/usr/local/bin/lit
+
 # Downloads and installs a prebuilt LLVM/MLIR toolchain for the current OS and architecture. Uses `zstd`.
 RUN curl -LsSf https://github.com/munich-quantum-software/setup-mlir/releases/latest/download/setup-mlir.sh \
   | bash -s -- -v 22.1.0 -p /opt/llvm
+
+ENV MLIR_DIR=/opt/llvm/lib/cmake/mlir

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
   },
   "postCreateCommand": "prek install",
   "remoteEnv": {
-    "UV_PYTHON": "3.14"
+    "UV_PYTHON": "3.14",
+    "LIT_BIN": "/usr/local/bin/lit",
+    "MLIR_DIR": "/opt/llvm/lib/cmake/mlir"
   },
   "customizations": {
     "vscode": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,7 +33,7 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -56,7 +56,7 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -79,7 +79,7 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -93,7 +93,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
     with:
       clang-version: 22
       build-project: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@456e00166299c5e98dbdbc32881651c9611db9f7 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -28,18 +28,19 @@ jobs:
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
         compiler: [gcc]
-        config: [Release]
+        preset: [release]
         include:
           - runs-on: ubuntu-24.04
             compiler: gcc
-            config: Debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@456e00166299c5e98dbdbc32881651c9611db9f7 # v1.18.0
+            preset: debug
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
-      config: ${{ matrix.config }}
       setup-mlir: true
       llvm-version: 22.1.0
+      use-cmake-presets: true
+      preset-name: ${{ matrix.preset }}
 
   cpp-tests-macos:
     name: 🇨‌ Test 🍎
@@ -50,19 +51,19 @@ jobs:
       matrix:
         runs-on: [macos-26, macos-26-intel]
         compiler: [clang]
-        config: [Release]
+        preset: [release]
         include:
           - runs-on: macos-26
             compiler: clang
-            config: Debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@456e00166299c5e98dbdbc32881651c9611db9f7 # v1.18.0
+            preset: debug
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
-      config: ${{ matrix.config }}
-      cmake-args: -DMQT_CORE_WITH_GMP=ON
       setup-mlir: true
       llvm-version: 22.1.0
+      use-cmake-presets: true
+      preset-name: ${{ matrix.preset }}
 
   cpp-tests-windows:
     name: 🇨‌ Test 🏁
@@ -73,25 +74,26 @@ jobs:
       matrix:
         runs-on: [windows-2025, windows-11-arm]
         compiler: [msvc]
-        config: [Release]
+        preset: [release-windows]
         include:
           - runs-on: windows-2025
             compiler: msvc
-            config: Debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@456e00166299c5e98dbdbc32881651c9611db9f7 # v1.18.0
+            preset: debug-windows
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
-      config: ${{ matrix.config }}
       setup-mlir: true
       llvm-version: 22.1.0
+      use-cmake-presets: true
+      preset-name: ${{ matrix.preset }}
 
   # This job runs clang-tidy and posts the results as a PR comment
   cpp-linter:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@456e00166299c5e98dbdbc32881651c9611db9f7 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
     with:
       clang-version: 22
       build-project: true
@@ -99,6 +101,7 @@ jobs:
       cpp-linter-extra-args: "-std=c++20"
       setup-mlir: true
       llvm-version: 22.1.0
+      use-cmake-presets: true
     permissions:
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments
@@ -122,10 +125,6 @@ jobs:
             ${{
               fromJSON(needs.change-detection.outputs.run-cpp-tests)
               && '' || 'cpp-tests-ubuntu,cpp-tests-macos,cpp-tests-windows,'
-            }}
-            ${{
-              fromJSON(needs.change-detection.outputs.run-cpp-tests)
-              && '' || 'cpp-coverage,'
             }}
             ${{
               fromJSON(needs.change-detection.outputs.run-cpp-linter)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,7 +33,7 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -56,7 +56,7 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -79,7 +79,7 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -93,7 +93,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@1ab3de9c2ed635f0944a3eaf3333cd3b4fcb3174 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@e9ad7c5f4542993e068f8105fdfed9a9d80ba1b5 # v1.18.0
     with:
       clang-version: 22
       build-project: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@ae263e66c071e9f0b79f41166577190085c10b27 # v2.0.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,7 +33,7 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@ae263e66c071e9f0b79f41166577190085c10b27 # v2.0.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -55,7 +55,7 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@ae263e66c071e9f0b79f41166577190085c10b27 # v2.0.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -77,12 +77,13 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@ae263e66c071e9f0b79f41166577190085c10b27 # v2.0.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
       llvm-version: 22.1.0
+      mlir-debug: ${{ matrix.preset == 'debug-windows' }}
       preset-name: ${{ matrix.preset }}
 
   # This job runs clang-tidy and posts the results as a PR comment
@@ -90,7 +91,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@ae263e66c071e9f0b79f41166577190085c10b27 # v2.0.0
     with:
       clang-version: 22
       build-project: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,13 +33,12 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
       llvm-version: 22.1.0
-      use-cmake-presets: true
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-macos:
@@ -56,13 +55,12 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
       llvm-version: 22.1.0
-      use-cmake-presets: true
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-windows:
@@ -79,13 +77,12 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
       llvm-version: 22.1.0
-      use-cmake-presets: true
       preset-name: ${{ matrix.preset }}
 
   # This job runs clang-tidy and posts the results as a PR comment
@@ -93,7 +90,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@d2bb7d4b9fc2927b1c5f26d8c93f8ded02f67341 # v1.18.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@2ff90764526a4d0dc701784e307e4aa0449b7d4e # v1.19.0
     with:
       clang-version: 22
       build-project: true
@@ -101,7 +98,6 @@ jobs:
       cpp-linter-extra-args: "-std=c++20"
       setup-mlir: true
       llvm-version: 22.1.0
-      use-cmake-presets: true
     permissions:
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,8 +6,8 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "MLIR_DIR": "$env(MLIR_DIR)",
-        "LLVM_EXTERNAL_LIT": "$env(LIT_BIN)"
+        "MLIR_DIR": "$env{MLIR_DIR}",
+        "LLVM_EXTERNAL_LIT": "$env{LIT_BIN}"
       }
     },
     {
@@ -79,7 +79,7 @@
     {
       "name": "lint",
       "inherits": "base-ninja",
-      "displayName": "Lint config",
+      "displayName": "lint config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -101,6 +101,16 @@
       "configuration": "Release"
     },
     {
+      "name": "debug-windows",
+      "configurePreset": "debug-windows",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows",
+      "configurePreset": "release-windows",
+      "configuration": "Release"
+    },
+    {
       "name": "lint",
       "configurePreset": "lint",
       "configuration": "Debug"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,17 +4,38 @@
     {
       "name": "base",
       "hidden": true,
-      "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "MLIR_DIR": "/opt/llvm/lib/cmake/mlir",
-        "LLVM_DIR": "/opt/llvm/lib/cmake/llvm",
-        "LLVM_EXTERNAL_LIT": "/usr/local/bin/lit"
+        "MLIR_DIR": "$env(MLIR_DIR)",
+        "LLVM_EXTERNAL_LIT": "$env(LIT_BIN)"
       }
     },
     {
-      "name": "dev",
+      "name": "base-ninja",
+      "hidden": true,
       "inherits": "base",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "description": "Default configuration for non-Windows builds. Uses the Ninja generator",
+      "generator": "Ninja"
+    },
+    {
+      "name": "base-windows",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "description": "Default configuration for Windows builds. Uses the default generator"
+    },
+    {
+      "name": "dev",
+      "inherits": "base-ninja",
       "displayName": "dev config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -23,7 +44,7 @@
     },
     {
       "name": "debug",
-      "inherits": "base",
+      "inherits": "base-ninja",
       "displayName": "debug config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -32,10 +53,35 @@
     },
     {
       "name": "release",
-      "inherits": "base",
+      "inherits": "base-ninja",
       "displayName": "release config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "debug-windows",
+      "inherits": "base-windows",
+      "displayName": "debug config (Windows)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "LLVM_ENABLE_ASSERTIONS": "ON"
+      }
+    },
+    {
+      "name": "release-windows",
+      "inherits": "base-windows",
+      "displayName": "release config (Windows)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "lint",
+      "inherits": "base-ninja",
+      "displayName": "Lint config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     }
   ],
@@ -46,11 +92,52 @@
     },
     {
       "name": "debug",
-      "configurePreset": "debug"
+      "configurePreset": "debug",
+      "configuration": "Debug"
     },
     {
       "name": "release",
-      "configurePreset": "release"
+      "configurePreset": "release",
+      "configuration": "Release"
+    },
+    {
+      "name": "lint",
+      "configurePreset": "lint",
+      "configuration": "Debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "output": { "outputOnFailure": true },
+      "execution": {
+        "timeout": 600
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "configurePreset": "debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "configurePreset": "release",
+      "configuration": "Release"
+    },
+    {
+      "name": "debug-windows",
+      "inherits": "base",
+      "configurePreset": "debug-windows",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows",
+      "inherits": "base",
+      "configurePreset": "release-windows",
+      "configuration": "Release"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,15 +11,15 @@
       }
     },
     {
-      "name": "base-ninja",
+      "name": "base-unix",
       "hidden": true,
       "inherits": "base",
       "condition": {
-        "type": "notEquals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": ["Linux", "Darwin"]
       },
-      "description": "Default configuration for linux and macos builds.",
+      "description": "Default configuration for Linux and macOS builds",
       "generator": "Ninja"
     },
     {
@@ -31,11 +31,11 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "description": "Default configuration for Windows builds."
+      "description": "Default configuration for Windows builds"
     },
     {
       "name": "dev",
-      "inherits": "base-ninja",
+      "inherits": "base-unix",
       "displayName": "dev config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -44,7 +44,7 @@
     },
     {
       "name": "debug",
-      "inherits": "base-ninja",
+      "inherits": "base-unix",
       "displayName": "debug config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -53,10 +53,18 @@
     },
     {
       "name": "release",
-      "inherits": "base-ninja",
+      "inherits": "base-unix",
       "displayName": "release config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "lint",
+      "inherits": "base-unix",
+      "displayName": "lint config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -75,14 +83,6 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
-    },
-    {
-      "name": "lint",
-      "inherits": "base-ninja",
-      "displayName": "lint config",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
     }
   ],
   "buildPresets": [
@@ -92,13 +92,15 @@
     },
     {
       "name": "debug",
-      "configurePreset": "debug",
-      "configuration": "Debug"
+      "configurePreset": "debug"
     },
     {
       "name": "release",
-      "configurePreset": "release",
-      "configuration": "Release"
+      "configurePreset": "release"
+    },
+    {
+      "name": "lint",
+      "configurePreset": "lint"
     },
     {
       "name": "debug-windows",
@@ -109,11 +111,6 @@
       "name": "release-windows",
       "configurePreset": "release-windows",
       "configuration": "Release"
-    },
-    {
-      "name": "lint",
-      "configurePreset": "lint",
-      "configuration": "Debug"
     }
   ],
   "testPresets": [
@@ -128,14 +125,12 @@
     {
       "name": "debug",
       "inherits": "base",
-      "configurePreset": "debug",
-      "configuration": "Debug"
+      "configurePreset": "debug"
     },
     {
       "name": "release",
       "inherits": "base",
-      "configurePreset": "release",
-      "configuration": "Release"
+      "configurePreset": "release"
     },
     {
       "name": "debug-windows",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,7 +19,7 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "description": "Default configuration for non-Windows builds. Uses the Ninja generator",
+      "description": "Default configuration for linux and macos builds.",
       "generator": "Ninja"
     },
     {
@@ -31,7 +31,7 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "description": "Default configuration for Windows builds. Uses the default generator"
+      "description": "Default configuration for Windows builds."
     },
     {
       "name": "dev",


### PR DESCRIPTION
This PR updates [munich-quantum-toolkit/workflows](https://github.com/munich-quantum-toolkit/workflows) to `v2.0.0`, which adds support (well, requires) CMake presets.

Fixes #27