### PR TITLE
Update workflows to use LLVM 22.1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@143bf51e7192c31e76abafe58e3732c5aff9c69b # v2.0.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,12 +33,12 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@143bf51e7192c31e76abafe58e3732c5aff9c69b # v2.0.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.0
+      llvm-version: 22.1.7
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-macos:
@@ -55,12 +55,12 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@143bf51e7192c31e76abafe58e3732c5aff9c69b # v2.0.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.0
+      llvm-version: 22.1.7
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-windows:
@@ -77,12 +77,12 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@143bf51e7192c31e76abafe58e3732c5aff9c69b # v2.0.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.0
+      llvm-version: 22.1.7
       mlir-debug: ${{ matrix.preset == 'debug-windows' }}
       preset-name: ${{ matrix.preset }}
 
@@ -91,14 +91,14 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@143bf51e7192c31e76abafe58e3732c5aff9c69b # v2.0.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
     with:
       clang-version: 22
       build-project: true
       files-changed-only: true
       cpp-linter-extra-args: "-std=c++20"
       setup-mlir: true
-      llvm-version: 22.1.0
+      llvm-version: 22.1.7
     permissions:
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 22.1.5
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-macos:
@@ -60,7 +60,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 22.1.5
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-windows:
@@ -70,11 +70,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [windows-2022, windows-11-arm]
+        runs-on: [windows-2025, windows-11-arm]
         compiler: [msvc]
         preset: [release-windows]
         include:
-          - runs-on: windows-2022
+          - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
@@ -82,7 +82,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 22.1.5
       mlir-debug: ${{ matrix.preset == 'debug-windows' }}
       preset-name: ${{ matrix.preset }}
 
@@ -98,7 +98,7 @@ jobs:
       files-changed-only: true
       cpp-linter-extra-args: "-std=c++20"
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 22.1.5
     permissions:
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,7 +33,7 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -55,7 +55,7 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -77,7 +77,7 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -91,7 +91,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
     with:
       clang-version: 22
       build-project: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [windows-2025, windows-11-arm]
+        runs-on: [windows-2022, windows-11-arm]
         compiler: [msvc]
         preset: [release-windows]
         include:
-          - runs-on: windows-2025
+          - runs-on: windows-2022
             compiler: msvc
             preset: debug-windows
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,12 +33,12 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.5
+      llvm-version: 22.1.7
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-macos:
@@ -55,12 +55,12 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.5
+      llvm-version: 22.1.7
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-windows:
@@ -77,12 +77,12 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.5
+      llvm-version: 22.1.7
       mlir-debug: ${{ matrix.preset == 'debug-windows' }}
       preset-name: ${{ matrix.preset }}
 
@@ -91,14 +91,14 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@eeea704310e1f9753ce49ac9a276145121f4713c # v2.1.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@e4b59d75501df329f34e77459e1818ac4fe149f2 # v2.1.0
     with:
       clang-version: 22
       build-project: true
       files-changed-only: true
       cpp-linter-extra-args: "-std=c++20"
       setup-mlir: true
-      llvm-version: 22.1.5
+      llvm-version: 22.1.7
     permissions:
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments


### PR DESCRIPTION
This PR updates [munich-quantum-toolkit/workflows](https://github.com/munich-quantum-toolkit/workflows) to the latest version and updates the workflows to use LLVM 22.1.7.