### PR TITLE
75 qrisp to qir

### DIFF
--- a/mlir/include/qcc/Conversion/ToQIR/Constants.h
+++ b/mlir/include/qcc/Conversion/ToQIR/Constants.h
@@ -68,4 +68,16 @@ static constexpr llvm::StringLiteral qirQisX = "__quantum__qis__x__body";
 /// CX gate controlled on first qubit/ptr.
 static constexpr llvm::StringLiteral qirQisCX = "__quantum__qis__cx__body";
 
+/// Single target S gate.
+static constexpr llvm::StringLiteral qirQisS = "__quantum__qis__s__body";
+
+/// Single target S† gate.
+static constexpr llvm::StringLiteral qirQisSdg = "__quantum__qis__sdg__body";
+
+/// Single target T gate.
+static constexpr llvm::StringLiteral qirQisT = "__quantum__qis__t__body";
+
+/// Single target T† gate.
+static constexpr llvm::StringLiteral qirQisTdg = "__quantum__qis__tdg__body";
+
 } // namespace qcc

--- a/mlir/lib/Conversion/JaspToQC/JaspToQC.cpp
+++ b/mlir/lib/Conversion/JaspToQC/JaspToQC.cpp
@@ -262,7 +262,9 @@ struct ConvertJaspQuantumGateOp final : OpConversionPattern<jasp::QuantumGateOp>
     TRY_CONVERT_GATE("rz", qc::RZOp, 0, 1, 1);
     TRY_CONVERT_GATE("crz", qc::RZOp, 1, 1, 1);
     TRY_CONVERT_GATE("s", qc::SOp, 0, 1, 0);
+    TRY_CONVERT_GATE("s_dg", qc::SdgOp, 0, 1, 0);
     TRY_CONVERT_GATE("t", qc::TOp, 0, 1, 0);
+    TRY_CONVERT_GATE("t_dg", qc::TdgOp, 0, 1, 0);
     TRY_CONVERT_GATE("sx", qc::SXOp, 0, 1, 0);
     TRY_CONVERT_GATE("swap", qc::SWAPOp, 0, 2, 0);
     TRY_CONVERT_GATE("rxx", qc::RXXOp, 0, 2, 1);

--- a/mlir/lib/Conversion/ToQIR/CMakeLists.txt
+++ b/mlir/lib/Conversion/ToQIR/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_conversion_library(
   MLIRLLVMCommonConversion
   MLIRTransforms
   MLIRFuncToLLVM
+  MLIRSCFToControlFlow
   # Core MLIR
   MLIRIR
   MLIRPass)

--- a/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
+++ b/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
@@ -48,6 +48,10 @@ static StringRef mapUnitaryToQIS(qc::UnitaryOpInterface unitaryOp) {
     return llvm::TypeSwitch<Operation*, StringRef>(unitaryOp)
         .Case<qc::XOp>([](auto) { return qcc::qirQisX; })
         .Case<qc::HOp>([](auto) { return qcc::qirQisH; })
+        .Case<qc::TOp>([](auto) { return qcc::qirQisT; })
+        .Case<qc::TdgOp>([](auto) { return qcc::qirQisTdg; })
+        .Case<qc::SOp>([](auto) { return qcc::qirQisS; })
+        .Case<qc::SdgOp>([](auto) { return qcc::qirQisSdg; })
         .Default([](auto) { return ""; });
   }
 

--- a/mlir/lib/Conversion/ToQIR/FinalizeToQIR.cpp
+++ b/mlir/lib/Conversion/ToQIR/FinalizeToQIR.cpp
@@ -20,6 +20,9 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
+#include <mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h>
+
 using namespace mlir;
 
 namespace {
@@ -74,6 +77,9 @@ protected:
       RewritePatternSet patterns(ctx);
 
       populateFuncToLLVMConversionPatterns(typeConverter, patterns);
+
+      populateSCFToControlFlowConversionPatterns(patterns);
+      cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
 
       if (failed(applyFullConversion(moduleOp, target, std::move(patterns)))) {
         return signalPassFailure();

--- a/mlir/lib/Conversion/ToQIR/PrepToQIR.cpp
+++ b/mlir/lib/Conversion/ToQIR/PrepToQIR.cpp
@@ -45,6 +45,10 @@ protected:
     fnMZ->setAttr("passthrough", builder.getStrArrayAttr({"irreversible"}));
     createVoidFnDecl(qcc::qirQisH, 1);
     createVoidFnDecl(qcc::qirQisX, 1);
+    createVoidFnDecl(qcc::qirQisS, 1);
+    createVoidFnDecl(qcc::qirQisSdg, 1);
+    createVoidFnDecl(qcc::qirQisT, 1);
+    createVoidFnDecl(qcc::qirQisTdg, 1);
     createVoidFnDecl(qcc::qirQisCX, 2);
 
     addQIRModuleFlags();

--- a/mlir/test/tools/qcc-opt/jasp-to-qc-gates-test.mlir
+++ b/mlir/test/tools/qcc-opt/jasp-to-qc-gates-test.mlir
@@ -32,6 +32,9 @@ module @jasp_module {
     %s20 = jasp.quantum_gate "rzz"(%q0, %q1, %f1), %s19 : (!jasp.Qubit, !jasp.Qubit, tensor<f64>), !jasp.QuantumState -> !jasp.QuantumState
     %s21 = jasp.quantum_gate "xxyy"(%q0, %q1, %f1, %f2), %s20 : (!jasp.Qubit, !jasp.Qubit, tensor<f64>, tensor<f64>), !jasp.QuantumState -> !jasp.QuantumState
 
+    %s22 = jasp.quantum_gate "t_dg"(%q0), %s4 : (!jasp.Qubit), !jasp.QuantumState -> !jasp.QuantumState
+    %s23 = jasp.quantum_gate "s_dg"(%q0), %s4 : (!jasp.Qubit), !jasp.QuantumState -> !jasp.QuantumState
+
     %state_out = jasp.quantum_gate "gphase"(%f1), %s21 : (tensor<f64>), !jasp.QuantumState -> !jasp.QuantumState
 
     return

--- a/mlir/test/tools/qcc/example_teleport.mlir
+++ b/mlir/test/tools/qcc/example_teleport.mlir
@@ -35,7 +35,6 @@ builtin.module @jasp_module {
 // CHECK:    %[[CONSTANT_0:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:    %[[ZERO:.*]] = llvm.mlir.zero : !llvm.ptr
 // CHECK:    llvm.call @__quantum__rt__initialize(%[[ZERO]]) : (!llvm.ptr) -> ()
-
 // CHECK:    %[[INTTOPTR_0:.*]] = llvm.inttoptr %[[CONSTANT_0]] : i64 to !llvm.ptr
 // CHECK:    llvm.call @__quantum__qis__h__body(%[[INTTOPTR_0]]) : (!llvm.ptr) -> ()
 // CHECK:    llvm.call @__quantum__qis__t__body(%[[INTTOPTR_0]]) : (!llvm.ptr) -> ()

--- a/mlir/test/tools/qcc/example_teleport.mlir
+++ b/mlir/test/tools/qcc/example_teleport.mlir
@@ -1,6 +1,6 @@
 // RUN: qcc -o - %s | FileCheck %s
 
-// A simple teleportation program, written in jasp and compiled to mlir.
+// A simple teleportation program, written in qrisp and compiled to mlir.
 // Tests the lowering of control flow to llvm.
 builtin.module @jasp_module {
   func.func public @main(%arg0 : !jasp.QuantumState) -> (tensor<i1>, !jasp.QuantumState) attributes {qcc.entry_point} {

--- a/mlir/test/tools/qcc/example_teleport.mlir
+++ b/mlir/test/tools/qcc/example_teleport.mlir
@@ -2,6 +2,7 @@
 
 // A simple teleportation program, written in qrisp and compiled to mlir.
 // Tests the lowering of control flow to llvm.
+// TODO: modify once qrisp integration test framework is merged.
 builtin.module @jasp_module {
   func.func public @main(%arg0 : !jasp.QuantumState) -> (tensor<i1>, !jasp.QuantumState) attributes {qcc.entry_point} {
     %0 = arith.constant dense<2> : tensor<i64>

--- a/mlir/test/tools/qcc/example_teleport.mlir
+++ b/mlir/test/tools/qcc/example_teleport.mlir
@@ -1,5 +1,7 @@
 // RUN: qcc -o - %s | FileCheck %s
 
+// A simple teleportation program, written in jasp and compiled to mlir.
+// Tests the lowering of control flow to llvm.
 builtin.module @jasp_module {
   func.func public @main(%arg0 : !jasp.QuantumState) -> (tensor<i1>, !jasp.QuantumState) attributes {qcc.entry_point} {
     %0 = arith.constant dense<2> : tensor<i64>

--- a/mlir/test/tools/qcc/example_teleport.mlir
+++ b/mlir/test/tools/qcc/example_teleport.mlir
@@ -1,0 +1,67 @@
+// RUN: qcc -o - %s | FileCheck %s
+
+builtin.module @jasp_module {
+  func.func public @main(%arg0 : !jasp.QuantumState) -> (tensor<i1>, !jasp.QuantumState) attributes {qcc.entry_point} {
+    %0 = arith.constant dense<2> : tensor<i64>
+    %1, %2 = jasp.create_qubits %0, %arg0 : !jasp.QuantumState, tensor<i64> -> !jasp.QubitArray, !jasp.QuantumState
+    %3 = arith.constant dense<0> : tensor<i64>
+    %4 = jasp.get_qubit %1, %3 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
+    %5 = jasp.quantum_gate "h" (%4) , %2 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+    %6 = jasp.quantum_gate "t" (%4) , %5 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+    %7 = arith.constant dense<1> : tensor<i64>
+    %8 = jasp.get_qubit %1, %7 : !jasp.QubitArray, tensor<i64> -> !jasp.Qubit
+    %9 = jasp.quantum_gate "cx" (%4, %8) , %6 : (!jasp.Qubit, !jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+    %10, %11 = jasp.measure %4, %9 : !jasp.Qubit, !jasp.QuantumState -> tensor<i1>, !jasp.QuantumState
+    %12 = tensor.extract %10[] : tensor<i1>
+    %13 = arith.constant true
+    %14 = arith.xori %12, %13 : i1
+    %15 = scf.if %14 -> (!jasp.QuantumState) {
+      scf.yield %11 : !jasp.QuantumState
+    } else {
+      %16 = jasp.quantum_gate "s" (%8) , %11 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+      scf.yield %16 : !jasp.QuantumState
+    }
+    %17 = jasp.quantum_gate "t_dg" (%8) , %15 : (!jasp.Qubit) , !jasp.QuantumState -> !jasp.QuantumState
+    %18, %19 = jasp.measure %8, %17 : !jasp.Qubit, !jasp.QuantumState -> tensor<i1>, !jasp.QuantumState
+    func.return %18, %19 : tensor<i1>, !jasp.QuantumState
+  }
+}
+
+// CHECK-LABEL: llvm.func @main() attributes {passthrough = ["entry_point", ["output_labeling_schema", "schema_id"], ["qir_profiles", "adaptive_profile"], ["required_num_qubits", "2"], ["required_num_results", "2"]]} {
+// CHECK:    %[[ADDRESS:.*]] = llvm.mlir.addressof @".qir_dummy_label" : !llvm.ptr
+// CHECK:    %[[CONSTANT_1:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:    %[[CONSTANT_0:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:    %[[ZERO:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK:    llvm.call @__quantum__rt__initialize(%[[ZERO]]) : (!llvm.ptr) -> ()
+
+// CHECK:    %[[INTTOPTR_0:.*]] = llvm.inttoptr %[[CONSTANT_0]] : i64 to !llvm.ptr
+// CHECK:    llvm.call @__quantum__qis__h__body(%[[INTTOPTR_0]]) : (!llvm.ptr) -> ()
+// CHECK:    llvm.call @__quantum__qis__t__body(%[[INTTOPTR_0]]) : (!llvm.ptr) -> ()
+// CHECK:    %[[INTTOPTR_1:.*]] = llvm.inttoptr %[[CONSTANT_1]] : i64 to !llvm.ptr
+// CHECK:    llvm.call @__quantum__qis__cx__body(%[[INTTOPTR_0]], %[[INTTOPTR_1]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK:    llvm.call @__quantum__qis__mz__body(%[[INTTOPTR_0]], %[[INTTOPTR_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK:    %[[READ_RESULT_0:.*]] = llvm.call @__quantum__rt__read_result(%[[INTTOPTR_0]]) : (!llvm.ptr) -> i1
+// CHECK:    llvm.cond_br %[[READ_RESULT_0]], ^bb1, ^bb2
+// CHECK:  ^bb1:  // pred: ^bb0
+// CHECK:    llvm.call @__quantum__qis__s__body(%[[INTTOPTR_1]]) : (!llvm.ptr) -> ()
+// CHECK:    llvm.br ^bb2
+// CHECK:  ^bb2:  // 2 preds: ^bb0, ^bb1
+// CHECK:    llvm.call @__quantum__qis__tdg__body(%[[INTTOPTR_1]]) : (!llvm.ptr) -> ()
+// CHECK:    llvm.call @__quantum__qis__mz__body(%[[INTTOPTR_1]], %[[INTTOPTR_1]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK:    %[[READ_RESULT_1:.*]] = llvm.call @__quantum__rt__read_result(%[[INTTOPTR_1]]) : (!llvm.ptr) -> i1
+// CHECK:    llvm.call @__quantum__rt__bool_record_output(%[[READ_RESULT_1]], %[[ADDRESS]]) : (i1, !llvm.ptr) -> ()
+// CHECK:    llvm.return
+// CHECK:  }
+// CHECK:  llvm.func @__quantum__rt__initialize(!llvm.ptr)
+// CHECK:  llvm.func @__quantum__rt__bool_record_output(i1, !llvm.ptr)
+// CHECK:  llvm.func @__quantum__rt__read_result(!llvm.ptr {llvm.readonly}) -> i1
+// CHECK:  llvm.func @__quantum__qis__mz__body(!llvm.ptr, !llvm.ptr {llvm.writeonly}) attributes {passthrough = ["irreversible"]}
+// CHECK:  llvm.func @__quantum__qis__h__body(!llvm.ptr)
+// CHECK:  llvm.func @__quantum__qis__x__body(!llvm.ptr)
+// CHECK:  llvm.func @__quantum__qis__s__body(!llvm.ptr)
+// CHECK:  llvm.func @__quantum__qis__sdg__body(!llvm.ptr)
+// CHECK:  llvm.func @__quantum__qis__t__body(!llvm.ptr)
+// CHECK:  llvm.func @__quantum__qis__tdg__body(!llvm.ptr)
+// CHECK:  llvm.func @__quantum__qis__cx__body(!llvm.ptr, !llvm.ptr)
+// CHECK:  llvm.module_flags [#llvm.mlir.module_flag<error, "qir_major_version", 2 : i32>, #llvm.mlir.module_flag<max, "qir_minor_version", 1 : i32>, #llvm.mlir.module_flag<error, "dynamic_qubit_management", 0 : i32>, #llvm.mlir.module_flag<error, "dynamic_result_management", 0 : i32>, #llvm.mlir.module_flag<error, "ir_functions", 1 : i32>, #llvm.mlir.module_flag<error, "backwards_branching", 1 : i32>, #llvm.mlir.module_flag<error, "multiple_target_branching", 0 : i32>, #llvm.mlir.module_flag<error, "multiple_return_points", 0 : i32>]
+// CHECK:  llvm.mlir.global internal constant @".qir_dummy_label"("dummy_label\00") {addr_space = 0 : i32}


### PR DESCRIPTION
Relates to #75 (proper tests follow in a separate PR). Adds the missing gates and lowers scf to llvm.