### PR TITLE
Switched test target from test-qcc-project to check-qcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Run the tests like so:
 
 ```shell
 # Rebuilds and runs all tests:
-cmake --build build/dev --target test-qcc-project
+cmake --build build/dev --target check-qcc
 
 # Run specific tests (filters by filename):
 lit build/dev/mlir/test/ -v --filter "convert"

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -3,8 +3,7 @@ configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in ${CMAKE_CU
 
 set(MLIR_COMPILER_TEST_DEPENDS FileCheck count not qcc-opt qcc qcc-lsp-server)
 
-add_lit_testsuite(test-qcc-project "Run the QCC project tests" ${CMAKE_CURRENT_BINARY_DIR} DEPENDS
+add_lit_testsuite(check-qcc "Run the QCC project tests" ${CMAKE_CURRENT_BINARY_DIR} DEPENDS
                   ${MLIR_COMPILER_TEST_DEPENDS})
 
-add_test(NAME test-qcc-project COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target
-                                       test-qcc-project)
+add_test(NAME check-qcc COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target check-qcc)


### PR DESCRIPTION
This is consistent with LLVM upstream. It reduces the mental burden (a little) when switching between llvm proper and our project (I use to recursively search for "check-" in the terminal to run the tests).