### PR TITLE
Simplify RUN commands by piping into qir-runner

### DIFF
--- a/mlir/test/tools/qcc/qrisp-integration/bell_state.mlir
+++ b/mlir/test/tools/qcc/qrisp-integration/bell_state.mlir
@@ -1,6 +1,5 @@
-// RUN: qcc %s -o %t.ll
-// RUN: FileCheck %s --check-prefix=CHECK-QIR < %t.ll
-// RUN: qir-runner --file %t.ll -s 5 | FileCheck %s --check-prefix=CHECK-SIM
+// RUN: qcc %s | FileCheck %s --check-prefix=CHECK-QIR
+// RUN: qcc %s | qir-runner -s 5 | FileCheck %s --check-prefix=CHECK-SIM
 
 // GENERATED FROM QRISP VERSION  git+https://github.com/eclipse-qrisp/Qrisp.git@b81ea2f979d21cd8d600e79d8b0c7066fe7cbe1b
 

--- a/mlir/test/tools/qcc/qrisp-integration/ghz.mlir
+++ b/mlir/test/tools/qcc/qrisp-integration/ghz.mlir
@@ -1,6 +1,5 @@
-// RUN: qcc %s -o %t.ll
-// RUN: FileCheck %s --check-prefix=CHECK-QIR < %t.ll
-// RUN: qir-runner --file %t.ll -s 5 | FileCheck %s --check-prefix=CHECK-SIM
+// RUN: qcc %s | FileCheck %s --check-prefix=CHECK-QIR
+// RUN: qcc %s | qir-runner -s 5 | FileCheck %s --check-prefix=CHECK-SIM
 
 // GENERATED FROM QRISP VERSION  git+https://github.com/eclipse-qrisp/Qrisp.git@b81ea2f979d21cd8d600e79d8b0c7066fe7cbe1b
 

--- a/mlir/test/tools/qcc/qrisp-integration/iqpe.mlir
+++ b/mlir/test/tools/qcc/qrisp-integration/iqpe.mlir
@@ -1,6 +1,5 @@
-// RUN: qcc %s -o %t.ll
-// RUN: FileCheck %s --check-prefix=CHECK-QIR < %t.ll
-// RUN: qir-runner --file %t.ll -s 5 | FileCheck %s --check-prefix=CHECK-SIM
+// RUN: qcc %s | FileCheck %s --check-prefix=CHECK-QIR
+// RUN: qcc %s | qir-runner -s 5 | FileCheck %s --check-prefix=CHECK-SIM
 
 // GENERATED FROM QRISP VERSION 0.9.5
 

--- a/mlir/test/tools/qcc/qrisp-integration/t_gate_teleportation.mlir
+++ b/mlir/test/tools/qcc/qrisp-integration/t_gate_teleportation.mlir
@@ -1,6 +1,5 @@
-// RUN: qcc %s -o %t.ll
-// RUN: FileCheck %s --check-prefix=CHECK-QIR < %t.ll
-// RUN: qir-runner --file %t.ll -s 5 | FileCheck %s --check-prefix=CHECK-SIM
+// RUN: qcc %s | FileCheck %s --check-prefix=CHECK-QIR
+// RUN: qcc %s | qir-runner -s 5 | FileCheck %s --check-prefix=CHECK-SIM
 
 // GENERATED FROM QRISP VERSION  git+https://github.com/eclipse-qrisp/Qrisp.git@b81ea2f979d21cd8d600e79d8b0c7066fe7cbe1b
 


### PR DESCRIPTION
Version 0.9.6 of `qirrunner` now supports reading QIR text from stdin. 

Only downside of the change is that now the compilation is run twice, so performance might be mildly worse. I don't think this is an issue now. Since we did encounter nondeterministic behavior previously it might even pay off. 