### PR TITLE
Operate convert-qc-to-qir on ModuleOp

### DIFF
--- a/mlir/include/qcc/Conversion/ToQIR/ToQIR.td
+++ b/mlir/include/qcc/Conversion/ToQIR/ToQIR.td
@@ -28,11 +28,11 @@ def PrepToQIR : Pass<"prep-to-qir", "mlir::ModuleOp"> {
   ];
 }
 
-def ConvertQCToQIR : Pass<"convert-qc-to-qir", "mlir::func::FuncOp"> {
+def ConvertQCToQIR : Pass<"convert-qc-to-qir", "mlir::ModuleOp"> {
   let summary = "Lowers the QC dialect into QIR (adaptive) conforming LLVM dialect.";
 
   let description = [{
-      The pass anchors to a function and guarantees the following:
+      The pass anchors to a module and guarantees the following:
 
       - The QIR initialization function is inserted at the start of the function.
       - Required QIR attributes (like `required_num_qubits`) are added to the function. Via `passthrough`.

--- a/mlir/include/qcc/Conversion/ToQIR/ToQIR.td
+++ b/mlir/include/qcc/Conversion/ToQIR/ToQIR.td
@@ -34,12 +34,11 @@ def ConvertQCToQIR : Pass<"convert-qc-to-qir", "mlir::ModuleOp"> {
   let description = [{
       The pass anchors to a module and guarantees the following:
 
-      - The QIR initialization function is inserted at the start of the function.
+      - Lowers all functions with the qcc.entry_point attribute to QIR conforming LLVM dialect.
+      - The QIR initialization function is inserted at the start of each of those functions.
       - Required QIR attributes (like `required_num_qubits`) are added to the function. Via `passthrough`.
       - `qc` gate and measurement ops are translated to QIR QIS function calls.
       - Only the llvm dialect (in the function body) is considered legal after this pass.
-      - TODO: To support some kind of output recording: We lower `aux.record_bool` to the
-        bool recording function. Currently no other output recording function are in use.
 
       TODO: For simplicity we assume that only entry point functions have
       quantum operations. Before we extend support we have to figure out how to

--- a/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
+++ b/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
@@ -343,11 +343,11 @@ protected:
         ;
       }
 
-      if (failed(setEntryPointAttrs())) {
+      if (failed(setEntryPointAttrs(funcOp))) {
         return WalkResult::interrupt();
       }
 
-      if (failed(insertRtInit())) {
+      if (failed(insertRtInit(funcOp, module))) {
         return WalkResult::interrupt();
       }
 
@@ -372,7 +372,7 @@ protected:
       if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
         return WalkResult::interrupt();
       }
-      removeQCStaticOps();
+      removeQCStaticOps(funcOp);
       return WalkResult::advance();
     });
 
@@ -382,11 +382,8 @@ protected:
   }
 
 private:
-  LogicalResult insertRtInit() {
-    func::FuncOp funcOp = getOperation();
-    auto moduleOp = funcOp->getParentOfType<ModuleOp>();
-    auto* ctx = funcOp.getContext();
-
+  LogicalResult static insertRtInit(func::FuncOp funcOp, ModuleOp moduleOp) {
+    auto* ctx = moduleOp.getContext();
     auto initFnDecl = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(qcc::qirRtInit);
 
     if (!initFnDecl) {
@@ -404,8 +401,8 @@ private:
     return llvm::success();
   }
 
-  uint64_t getRequiredNumQubits() {
-    const func::FuncOp funcOp = getOperation();
+  uint64_t static getRequiredNumQubits(func::FuncOp funcOp) {
+
     uint64_t numQubits = 0;
     funcOp->walk([&](qc::StaticOp op) -> void {
       auto index = op.getIndex();
@@ -415,11 +412,10 @@ private:
   }
 
   /// Attaches all the relevant QIR attributes (like `required_num_qubits`) to the function.
-  LogicalResult setEntryPointAttrs() {
-    func::FuncOp funcOp = getOperation();
+  LogicalResult static setEntryPointAttrs(func::FuncOp funcOp) {
     OpBuilder builder(funcOp.getContext());
 
-    auto requiredNumQubits = getRequiredNumQubits();
+    auto requiredNumQubits = getRequiredNumQubits(funcOp);
     auto requiredNumResults = requiredNumQubits; // TODO: holds only for HiSEP-Q!
 
     auto getKV = [&](StringRef key, StringRef value) {
@@ -437,8 +433,8 @@ private:
     return success();
   }
 
-  void removeQCStaticOps() {
-    getOperation()->walk([](qc::StaticOp op) { op.erase(); });
+  void static removeQCStaticOps(func::FuncOp funcOp) {
+    funcOp->walk([](qc::StaticOp op) { op.erase(); });
   }
 };
 

--- a/mlir/lib/Target/QIR/QIRTarget.cpp
+++ b/mlir/lib/Target/QIR/QIRTarget.cpp
@@ -25,7 +25,7 @@ void addLoweringPassesQIR(mlir::PassManager& pm) {
   pm.addPass(qcc::createPrepToQIR());
   mlir::OpPassManager& fpm = pm.nest<mlir::func::FuncOp>();
   fpm.addPass(mlir::createArithToLLVMConversionPass());
-  fpm.addPass(qcc::createConvertQCToQIR());
+  pm.addPass(qcc::createConvertQCToQIR());
   pm.addPass(mlir::createConvertControlFlowToLLVMPass());
   pm.addPass(qcc::createFinalizeToQIR());
 

--- a/mlir/test/tools/qcc-opt/ToQIR/convert-qc-to-qir.mlir
+++ b/mlir/test/tools/qcc-opt/ToQIR/convert-qc-to-qir.mlir
@@ -1,4 +1,4 @@
-// RUN: qcc-opt %s -convert-qc-to-qir | FileCheck %s
+// RUN: qcc-opt %s -convert-qc-to-qir --split-input-file | FileCheck %s
 
 func.func @test() -> i64 attributes { qcc.entry_point } {
     // CHECK-LABEL:   func.func @test() -> i64 attributes {
@@ -75,6 +75,25 @@ func.func @test() -> i64 attributes { qcc.entry_point } {
     // CHECK:           %[[EXIT_CODE:.*]] = arith.constant 0 : i64
     // CHECK:           return %[[EXIT_CODE]] : i64
 }
+
+// The pass assumes that these decls already exist.
+llvm.func @__quantum__rt__initialize(!llvm.ptr)
+llvm.func @__quantum__rt__bool_record_output(i1, !llvm.ptr)
+llvm.func @__quantum__rt__int_record_output(i64, !llvm.ptr)
+llvm.func @__quantum__rt__tuple_record_output(i64, !llvm.ptr)
+llvm.func @__quantum__rt__array_record_output(i64, !llvm.ptr)
+llvm.func @__quantum__rt__read_result(!llvm.ptr {llvm.readonly}) -> i1
+llvm.func @__quantum__qis__mz__body(!llvm.ptr, !llvm.ptr {llvm.writeonly}) attributes {passthrough = ["irreversible"]}
+llvm.func @__quantum__qis__h__body(!llvm.ptr)
+llvm.func @__quantum__qis__x__body(!llvm.ptr)
+llvm.func @__quantum__qis__cx__body(!llvm.ptr, !llvm.ptr)
+llvm.func @__quantum__qis__rz__body(f64, !llvm.ptr)
+
+// The label needed to lower `aux.record_int` to its corresponding runtime function:
+llvm.mlir.global internal constant @".qir_dummy_label"("dummy_label\00") {addr_space = 0 : i32}
+
+
+// -----
 
 func.func @test_memref_lowering() -> i64 attributes { qcc.entry_point } {
     %t = memref.alloc() : memref<3xi64>

--- a/mlir/test/tools/qcc-opt/ToQIR/export-to-qir-full-pipeline.mlir
+++ b/mlir/test/tools/qcc-opt/ToQIR/export-to-qir-full-pipeline.mlir
@@ -1,4 +1,4 @@
-// RUN: qcc-opt %s -pass-pipeline="builtin.module(prep-to-qir,func.func(convert-arith-to-llvm,convert-qc-to-qir),convert-cf-to-llvm,finalize-to-qir)" | mlir-translate -mlir-to-llvmir | FileCheck %s
+// RUN: qcc-opt %s -pass-pipeline="builtin.module(prep-to-qir,func.func(convert-arith-to-llvm),convert-qc-to-qir,convert-cf-to-llvm,finalize-to-qir)" | mlir-translate -mlir-to-llvmir | FileCheck %s
 
 func.func @simple_quantum_with_branching() -> i64 attributes { qcc.entry_point } {
     %0 = qc.static 1 : !qc.qubit


### PR DESCRIPTION
Conversion to QIR operates on function level. This can cause troubles when lowering to LLVM when there are multiple entry point functions. During the -convert-qc-to-qir pass (specifically when lowering memref or memory allocations to LLVM dialect), the pass attempts to declare or insert llvm.func @malloc, but the conversion patterns run multiple times and insert duplicate @malloc function declarations without checking if module.lookupSymbol("malloc") already exists.

Proposed solution:  Change ConvertQCToQIR to operate on mlir::ModuleOp